### PR TITLE
Bug Fix for Event Posting

### DIFF
--- a/lib/src/core.dart
+++ b/lib/src/core.dart
@@ -216,8 +216,12 @@ class EventDispatcher {
   bool post(dynamic event, {bool postDeadEvent: true}) {
     var name = _getName(event);
 
-    if (!_handlers.containsKey(name) && postDeadEvent) {
-      return post(new DeadEvent(event), postDeadEvent: false);
+    if (!_handlers.containsKey(name)) {
+      if (postDeadEvent) {
+        return post(new DeadEvent(event), postDeadEvent: false);
+      } else {
+        return false;
+      }
     }
 
     var handlers = _handlers[name];


### PR DESCRIPTION
There is a bug in the `post` method where if an event is posted which does not have a handler, it will throw a NullPointerException.

See https://gist.github.com/logangorence/63bcf367d65733910506 for an example of this.

I have fixed and tested it. It will definitely work this time.

Since this is a major bug fix, I recommend publishing a new version to pub after merging and bumping the version.
